### PR TITLE
Allow empty operations list

### DIFF
--- a/src/sml2mqtt/config/operations.py
+++ b/src/sml2mqtt/config/operations.py
@@ -326,7 +326,7 @@ OperationsTypeAnnotated: TypeAlias = Annotated[
     )
 ]
 
-OperationsListType = Annotated[list[OperationsTypeAnnotated], Len(min_length=1)]
+OperationsListType = Annotated[list[OperationsTypeAnnotated], Len(min_length=0)]
 
 
 def cleanup_validation_errors(msg: str) -> str:


### PR DESCRIPTION
The application terminates with a validation error when a device contains no `operation`.

#### Configuration
```yaml
devices:
  0123456789abcdef0123:
    values:
      - obis: 0100100700ff
        mqtt:
          topic: power
```

#### Output
```
Starting with sml2mqtt with user id: 1000 and group id: 20
Rename group dialout to sml2mqtt
Create user sml2mqtt with id 1000
1 validation error for Settings
devices.0123456789abcdef0123.values.0.operations
  List should have at least 1 item after validation, not 0 [type=too_short, input_value=[], input_type=list]
    For further information visit https://errors.pydantic.dev/2.10/v/too_short
```